### PR TITLE
Move from Regenerator to Kneden

### DIFF
--- a/mocha-babel.js
+++ b/mocha-babel.js
@@ -1,5 +1,5 @@
 require('babel-register')({
   presets: [require('babel-preset-es2015')],
-  plugins: [require('babel-plugin-transform-async-to-generator')],
+  plugins: [require('kneden')],
   only: /test/
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "bin": "bin/pouchdb-plugin-helper",
   "dependencies": {
     "babel-eslint": "^5.0.0-beta6",
-    "babel-plugin-transform-async-to-generator": "^6.3.13",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
@@ -19,6 +18,7 @@
     "eslint": "^2.0.0",
     "glob": "^7.0.0",
     "istanbul": "^0.4.1",
+    "kneden": "^0.4.1",
     "memdown": "^1.1.1",
     "mocha": "^2.3.4",
     "pouchdb": "^5.1.0",


### PR DESCRIPTION
Why? Well, to be honest, for non-browser environments there's little benefit. But I need to dogfood my own library, and I already tested for regressions.

[Kneden](https://github.com/marten-de-vries/kneden)
